### PR TITLE
Add security headers middleware and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,10 +256,10 @@ For a detailed development plan, refer to the [Specs.md](./Specs.md) file.
   - [X] Unit tests
   - [X] Integration tests
   - [X] Mock implementations
-- [ ] Security
-  - [ ] Rate limiting
-  - [ ] Security headers
-  - [ ] Input validation security
+- [X] Security
+  - [X] Rate limiting
+  - [X] Security headers
+  - [X] Input validation security
 
 ### Phase 5: Deployment and Monitoring
 

--- a/server/handlers/auth_handler.go
+++ b/server/handlers/auth_handler.go
@@ -120,7 +120,6 @@ func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Header().Set("Cache-Control", "no-store")
 	json.NewEncoder(w).Encode(response)
 }
@@ -179,7 +178,6 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Header().Set("Cache-Control", "no-store")
 	json.NewEncoder(w).Encode(response)
 }

--- a/server/middleware/security.go
+++ b/server/middleware/security.go
@@ -1,0 +1,40 @@
+package middleware
+
+import "net/http"
+
+type SecurityHeaders struct{}
+
+func NewSecurityHeaders() *SecurityHeaders {
+	return &SecurityHeaders{}
+}
+
+func (s *SecurityHeaders) Handler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Only set security headers if they haven't been set yet
+		headers := w.Header()
+		if headers.Get("X-Content-Type-Options") == "" {
+			headers.Set("X-Content-Type-Options", "nosniff")
+		}
+		if headers.Get("X-Frame-Options") == "" {
+			headers.Set("X-Frame-Options", "DENY")
+		}
+		if headers.Get("X-XSS-Protection") == "" {
+			headers.Set("X-XSS-Protection", "1; mode=block")
+		}
+		if headers.Get("Strict-Transport-Security") == "" {
+			headers.Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+		}
+		if headers.Get("Content-Security-Policy") == "" {
+			headers.Set("Content-Security-Policy", "default-src 'self'")
+		}
+		if headers.Get("Referrer-Policy") == "" {
+			headers.Set("Referrer-Policy", "strict-origin-when-cross-origin")
+		}
+		if headers.Get("Permissions-Policy") == "" {
+			headers.Set("Permissions-Policy", "geolocation=(), camera=(), microphone=()")
+		}
+
+		// Continue with the next handler
+		next.ServeHTTP(w, r)
+	})
+}

--- a/server/middleware/security_test.go
+++ b/server/middleware/security_test.go
@@ -1,0 +1,140 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSecurityHeaders(t *testing.T) {
+	tests := []struct {
+		name           string
+		existingHeader string
+		existingValue  string
+		expectedHeader string
+		expectedValue  string
+		shouldOverride bool
+	}{
+		{
+			name:           "Sets X-Content-Type-Options",
+			expectedHeader: "X-Content-Type-Options",
+			expectedValue:  "nosniff",
+			shouldOverride: false,
+		},
+		{
+			name:           "Sets X-Frame-Options",
+			expectedHeader: "X-Frame-Options",
+			expectedValue:  "DENY",
+			shouldOverride: false,
+		},
+		{
+			name:           "Sets X-XSS-Protection",
+			expectedHeader: "X-XSS-Protection",
+			expectedValue:  "1; mode=block",
+			shouldOverride: false,
+		},
+		{
+			name:           "Sets Strict-Transport-Security",
+			expectedHeader: "Strict-Transport-Security",
+			expectedValue:  "max-age=31536000; includeSubDomains",
+			shouldOverride: false,
+		},
+		{
+			name:           "Sets Content-Security-Policy",
+			expectedHeader: "Content-Security-Policy",
+			expectedValue:  "default-src 'self'",
+			shouldOverride: false,
+		},
+		{
+			name:           "Sets Referrer-Policy",
+			expectedHeader: "Referrer-Policy",
+			expectedValue:  "strict-origin-when-cross-origin",
+			shouldOverride: false,
+		},
+		{
+			name:           "Sets Permissions-Policy",
+			expectedHeader: "Permissions-Policy",
+			expectedValue:  "geolocation=(), camera=(), microphone=()",
+			shouldOverride: false,
+		},
+		{
+			name:           "Respects existing X-Content-Type-Options",
+			existingHeader: "X-Content-Type-Options",
+			existingValue:  "custom-value",
+			expectedHeader: "X-Content-Type-Options",
+			expectedValue:  "custom-value",
+			shouldOverride: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a new security headers middleware
+			security := NewSecurityHeaders()
+
+			// Create a test handler that we'll wrap with our middleware
+			nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Handler does nothing
+			})
+
+			// Create a test request
+			req := httptest.NewRequest("GET", "/test", nil)
+			rr := httptest.NewRecorder()
+
+			// If we're testing with existing headers, set them
+			if tt.existingHeader != "" {
+				rr.Header().Set(tt.existingHeader, tt.existingValue)
+			}
+
+			// Run the middleware
+			handler := security.Handler(nextHandler)
+			handler.ServeHTTP(rr, req)
+
+			// Check if the header was set correctly
+			gotValue := rr.Header().Get(tt.expectedHeader)
+			if tt.shouldOverride {
+				if gotValue != tt.expectedValue {
+					t.Errorf("handler didn't override header %s: got %v want %v",
+						tt.expectedHeader, gotValue, tt.expectedValue)
+				}
+			} else {
+				expectedValue := tt.expectedValue
+				if tt.existingHeader != "" {
+					expectedValue = tt.existingValue
+				}
+				if gotValue != expectedValue {
+					t.Errorf("handler set wrong value for %s: got %v want %v",
+						tt.expectedHeader, gotValue, expectedValue)
+				}
+			}
+		})
+	}
+}
+
+func TestAllSecurityHeadersPresent(t *testing.T) {
+	security := NewSecurityHeaders()
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	rr := httptest.NewRecorder()
+
+	handler := security.Handler(nextHandler)
+	handler.ServeHTTP(rr, req)
+
+	expectedHeaders := map[string]string{
+		"X-Content-Type-Options":    "nosniff",
+		"X-Frame-Options":           "DENY",
+		"X-XSS-Protection":          "1; mode=block",
+		"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+		"Content-Security-Policy":   "default-src 'self'",
+		"Referrer-Policy":           "strict-origin-when-cross-origin",
+		"Permissions-Policy":        "geolocation=(), camera=(), microphone=()",
+	}
+
+	for header, expectedValue := range expectedHeaders {
+		if got := rr.Header().Get(header); got != expectedValue {
+			t.Errorf("missing or incorrect security header %s: got %v want %v",
+				header, got, expectedValue)
+		}
+	}
+}

--- a/server/routes.go
+++ b/server/routes.go
@@ -19,6 +19,12 @@ func (s *Server) RegisterRoutes(conn *pgx.Conn, jwtManager auth.JWTManager, env 
 
 	queries := repository.New(conn)
 	r := chi.NewRouter()
+
+	// Add security headers middleware first
+	securityHeaders := customMiddleware.NewSecurityHeaders()
+	r.Use(securityHeaders.Handler)
+
+	// Add other middleware
 	r.Use(middleware.Logger)
 
 	r.Use(middleware.Recoverer)


### PR DESCRIPTION
# Description
Introduce a middleware for setting security headers to enhance application security. Remove redundant security header settings and adjust middleware order. Update the README to reflect the completion of security tasks.

## Type of Change
- [X] :sparkles: New feature (non-breaking change which adds functionality)

## Risk Assessment
- [X] :green_circle: Low Risk - Minor changes with minimal impact

## How Has This Been Tested?
Manual and unit tests
