### PR TITLE
Update Docker publish workflow for artifact attestation

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,7 +36,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/centsible:${{ github.event.release.tag_name }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/centsible
             ghcr.io/${{ github.repository }}
 
       - name: Build and push Docker images


### PR DESCRIPTION
Remove version tagging from the Docker image and add a step to generate artifact attestation during the publish workflow.